### PR TITLE
Fix Question topic parsing

### DIFF
--- a/quora/quora.py
+++ b/quora/quora.py
@@ -159,7 +159,7 @@ class Quora:
       raw_topics = soup.find_all('div', attrs={'class' : 'TopicListItem'})
       topics = []
       for topic in raw_topics:
-        topics.append(topic.findAll(text=True, recursive=True)[1])
+        topics.extend(text for text in topic.findAll(text=True, recursive=True) if text.strip() != "")
 
       answer_count = soup.find('div', attrs={'class' : 'answer_count'}).next.split()[0]
       question_text = list(soup.find('div', attrs = {'class' : 'question_text_edit'}).find('h1').children)[-1]

--- a/quora/quora.py
+++ b/quora/quora.py
@@ -156,10 +156,10 @@ class Quora:
     Scrapes the soup object to get details of a question.
     """
     try:
-      raw_topics = soup.find_all('span', attrs={'itemprop' : 'title'})
+      raw_topics = soup.find_all('div', attrs={'class' : 'TopicListItem'})
       topics = []
       for topic in raw_topics:
-        topics.append(topic.string)
+        topics.append(topic.findAll(text=True, recursive=True)[1])
 
       answer_count = soup.find('div', attrs={'class' : 'answer_count'}).next.split()[0]
       question_text = list(soup.find('div', attrs = {'class' : 'question_text_edit'}).find('h1').children)[-1]

--- a/tests/test_question_statistics.py
+++ b/tests/test_question_statistics.py
@@ -39,7 +39,7 @@ class TestQuestionStatistics:
     def test_exists(self):
         for stat in self.test_stats:
             assert stat['answer_count']
-            # assert stat['topics']
+            assert stat['topics']
 
     def test_type(self):
         for stat in self.test_stats:


### PR DESCRIPTION
Fixed Question topic parsing in `scrape_question_stats()` by targeting `div`'s of class `TopicListItem`.

Addresses #86.